### PR TITLE
Add manifest references to new global policy component

### DIFF
--- a/manifests/terraform_modules/manifest/manifest.xml
+++ b/manifests/terraform_modules/manifest/manifest.xml
@@ -12,4 +12,6 @@
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
     <linkfile src="linkfiles/.golangci.yaml" dest=".golangci.yaml" />
   </project>
+  <project name="caf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CAF_POLICY_VER}'>
+  </project>
 </manifest>

--- a/manifests/terragrunt/manifest/manifest.xml
+++ b/manifests/terragrunt/manifest/manifest.xml
@@ -8,4 +8,6 @@
    <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CAF_COMPONENTS_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
   </project>
+  <project name="caf-component-policy" path="components/policy" remote="launch-dso-platform" revision="refs/tags/0.1.0" dso_override_attribute_revision='${CAF_POLICY_VER}'>
+  </project>
 </manifest>


### PR DESCRIPTION
These will be pulled in for TF and TG modules, but won't be utilized until we update the build scripts and Makefiles to accommodate the new policy paths.