### PR TITLE
bumped version and changed repo name. depend name changed downstream

### DIFF
--- a/manifests/terragrunt/manifest/manifest.xml
+++ b/manifests/terragrunt/manifest/manifest.xml
@@ -3,7 +3,7 @@
     This manifest defines the behavior of aws terragrunt components
 -->
 <manifest>
-  <project name="caf-component-aws-terragrunt" path="components/terragrunt" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${TERRAGRUNT_VER}'>
+  <project name="caf-component-terragrunt" path="components/terragrunt" remote="launch-dso-platform" revision="refs/tags/0.2.1" dso_override_attribute_revision='${TERRAGRUNT_VER}'>
   </project>
    <project name="caf-components-tf-module" path="components/module" remote="launch-dso-platform" revision="refs/tags/0.2.0" dso_override_attribute_revision='${CAF_COMPONENTS_VER}'>
     <linkfile src="linkfiles/.pre-commit-config.yaml" dest=".pre-commit-config.yaml" />


### PR DESCRIPTION
- changing `caf-component-aws-terragrunt` to `caf-component-terragrunt`. This component is able to be used for multiple providers. 
- bumping version of `caf-component-terragrunt`